### PR TITLE
chore: update to node:16 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:16
 ENV XDG_CONFIG_HOME /github/workspace
 ENV WRANGLER_HOME /github/workspace
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This is a temporary fork of https://github.com/cloudflare/wrangler-action so we build our worker in node@16 with npm@7

fixes: https://github.com/cloudflare/wrangler-action/issues/59


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>